### PR TITLE
Compatibility tweaks

### DIFF
--- a/verifymessage.php
+++ b/verifymessage.php
@@ -8,6 +8,26 @@ if (extension_loaded('gmp')) {
 	die('GMP extension required.'); // It may be available in a package called "php5-gmp" or similar for your system
 }
 
+// Setup-stuff cribbed from index.php in the ECC repo
+spl_autoload_register(function ($f) {
+  $base = dirname(__FILE__)."/phpecc/";
+	$interfaceFile = $base . "classes/interface/" . $f . "Interface.php";
+
+	if (file_exists($interfaceFile)) {
+		require_once $interfaceFile;
+	}
+
+	$classFile = $base . "classes/" . $f . ".php";
+	if (file_exists($classFile)) {
+		require_once $classFile;
+	}
+
+	$utilFile = $base . "classes/util/" . $f . ".php";
+	if (file_exists($utilFile)) {
+		require_once $utilFile;
+	}
+});
+
 function isMessageSignatureValid($address, $signature, $message) {
   // curve definition
   // http://www.secg.org/download/aid-784/sec2-v2.pdf
@@ -175,24 +195,4 @@ function gmp2bin($v) {
 	}
 
 	return $binStr;
-}
-
-// Setup-stuff cribbed from index.php in the ECC repo
-function __autoload($f) {
-  $base = dirname(__FILE__)."/phpecc/";
-	$interfaceFile = $base . "classes/interface/" . $f . "Interface.php";
-
-	if (file_exists($interfaceFile)) {
-		require_once $interfaceFile;
-	}
-
-	$classFile = $base . "classes/" . $f . ".php";
-	if (file_exists($classFile)) {
-		require_once $classFile;
-	}
-
-	$utilFile = $base . "classes/util/" . $f . ".php";
-	if (file_exists($utilFile)) {
-		require_once $utilFile;
-	}
 }

--- a/verifymessage.php
+++ b/verifymessage.php
@@ -8,17 +8,15 @@ if (extension_loaded('gmp')) {
 	die('GMP extension required.'); // It may be available in a package called "php5-gmp" or similar for your system
 }
 
-// curve definition
-// http://www.secg.org/download/aid-784/sec2-v2.pdf
-$secp256k1 = new CurveFp(
-	'0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F', '0', '7');
-$secp256k1_G = new Point($secp256k1,
-	'0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798',
-	'0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8',
-	'0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141');
-
 function isMessageSignatureValid($address, $signature, $message) {
-	global $secp256k1_G;
+  // curve definition
+  // http://www.secg.org/download/aid-784/sec2-v2.pdf
+  $secp256k1 = new CurveFp(
+    '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F', '0', '7');
+  $secp256k1_G = new Point($secp256k1,
+    '0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798',
+    '0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8',
+    '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141');
 
 	// extract parameters
 	$address = base58check_decode($address);
@@ -198,4 +196,3 @@ function __autoload($f) {
 		require_once $utilFile;
 	}
 }
-


### PR DESCRIPTION
Including this within a larger PHP project fails if that project already defines an __autoload function. Also, __autoload is set to be deprecated in PHP with spl_autoload the recommended replacement. 

Also, my instance of PHP did not like calling global on the $secp256k1_G object so I moved it into the (only) function where it is called.

phpecc had one additional commit for "speedup" that I've included.
